### PR TITLE
Include `mmcv`s in requirements and update versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,19 +94,10 @@ To prepare the Python environment and install additional packages such as opencv
 
 ### Build environment
 
-We recommend a python version >=3.10 and cuda version =11.7. Then build environment as follows:
+We recommend a python version >=3.10 and cuda version==12.1. Then build environment as follows:
 
 ```shell
 pip install -r requirements.txt
-```
-
-### mmlab packages
-```bash
-pip install --no-cache-dir -U openmim 
-mim install mmengine 
-mim install "mmcv>=2.0.1" 
-mim install "mmdet>=3.1.0" 
-mim install "mmpose>=1.1.0" 
 ```
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,14 @@
-torch==2.0.1
+--extra-index-url https://download.pytorch.org/whl/cu121
+torch==2.1.2
+torchvision==0.16.2
 torchdiffeq==0.2.3
 torchmetrics==1.2.1
 torchsde==0.2.5
-torchvision==0.15.2
 accelerate==0.29.3
 av==11.0.0
 clip @ https://github.com/openai/CLIP/archive/d50d76daa670286dd6cacf3bcd80b5e4823fc8e1.zip#sha256=b5842c25da441d6c581b53a5c60e0c2127ebafe0f746f8e15561a006c6c3be6a
-decord==0.6.0
+decord==0.6.0; sys_platform != 'darwin' and platform_machine != 'arm64'
+eva-decord==0.6.1; sys_platform == 'darwin' and platform_machine == 'arm64'
 diffusers>=0.24.0,<=0.27.2
 einops==0.4.1
 imageio==2.33.0
@@ -19,6 +21,12 @@ opencv-python==4.8.1.78
 scikit-image==0.21.0
 scikit-learn==1.3.2
 transformers==4.33.1
-xformers==0.0.22
+xformers==0.0.23.post1
 moviepy==1.0.3
 wget==3.2
+wheel==0.43.0
+-f https://download.openmmlab.com/mmcv/dist/cu121/torch2.1/index.html
+mmcv==2.1.0
+mmengine==0.10.4
+mmdet==3.3.0
+mmpose==1.3.1


### PR DESCRIPTION
Changed:

1. update `torch` versions with CUDA enabled. ( As far as I know this doesn't make error in CPU-only device, but I didn't test on CPU-only device )
2. Install different `decord` on MacOS. ( https://github.com/TMElyralab/Comfyui-MusePose/pull/25 )
3. update `xformers` to latest compatible version
4. add `wheel` and include `mmcv`s in requirements ( without `wheel`, there's a bug that installing `mmcv` takes forever )
5. update README to reflect changes.

Tested with 
```
python pose_align.py --imgfn_refer ./assets/images/ref.png --vidfn ./assets/videos/dance.mp4
python test_stage_2.py --config ./configs/test_stage_2.yaml -W 512 -H 512
```
in my venv and confirmed that it works fine.